### PR TITLE
feat: UI改善 - レスポンシブデザインとホームボタンの追加

### DIFF
--- a/gasoline-record-app/src/lib/supabase.ts
+++ b/gasoline-record-app/src/lib/supabase.ts
@@ -5,4 +5,15 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 // Supabase クライアントの初期化
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    // セッションをlocalStorageに永続化
+    persistSession: true,
+    // トークンを自動的にリフレッシュ
+    autoRefreshToken: true,
+    // セッション検出を有効化
+    detectSessionInUrl: true,
+    // リフレッシュトークンの有効期間を延長（デフォルトは3600秒=1時間）
+    // 注意: これはクライアント側の設定で、実際のトークン有効期限はSupabaseダッシュボードで設定されます
+  },
+})

--- a/gasoline-record-app/src/views/FuelRecordCreateView.vue
+++ b/gasoline-record-app/src/views/FuelRecordCreateView.vue
@@ -3,13 +3,23 @@
     <Card class="form-card">
       <template #title>
         <div class="form-header">
-          <Button
-            icon="pi pi-arrow-left"
-            @click="$router.push('/fuel-records')"
-            text
-            rounded
-            class="back-button"
-          />
+          <div class="header-buttons">
+            <Button
+              icon="pi pi-home"
+              @click="$router.push('/')"
+              text
+              rounded
+              severity="secondary"
+              class="home-button"
+            />
+            <Button
+              icon="pi pi-arrow-left"
+              @click="$router.push('/fuel-records')"
+              text
+              rounded
+              class="back-button"
+            />
+          </div>
           <h1>給油記録の登録</h1>
         </div>
       </template>
@@ -286,6 +296,12 @@ const handleSubmit = async () => {
   gap: 1rem;
 }
 
+.header-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.home-button,
 .back-button {
   font-size: 1.5rem;
 }
@@ -376,8 +392,22 @@ const handleSubmit = async () => {
   flex: 1;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .fuel-record-create-container {
+    max-width: 800px;
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .fuel-record-create-container {
+    max-width: 900px;
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .fuel-record-create-container {
     padding: 1rem;
   }

--- a/gasoline-record-app/src/views/FuelRecordEditView.vue
+++ b/gasoline-record-app/src/views/FuelRecordEditView.vue
@@ -8,13 +8,23 @@
     <Card v-else-if="record" class="form-card">
       <template #title>
         <div class="form-header">
-          <Button
-            icon="pi pi-arrow-left"
-            @click="$router.push('/fuel-records')"
-            text
-            rounded
-            class="back-button"
-          />
+          <div class="header-buttons">
+            <Button
+              icon="pi pi-home"
+              @click="$router.push('/')"
+              text
+              rounded
+              severity="secondary"
+              class="home-button"
+            />
+            <Button
+              icon="pi pi-arrow-left"
+              @click="$router.push('/fuel-records')"
+              text
+              rounded
+              class="back-button"
+            />
+          </div>
           <h1>給油記録の編集</h1>
         </div>
       </template>
@@ -340,6 +350,12 @@ const handleSubmit = async () => {
   gap: 1rem;
 }
 
+.header-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.home-button,
 .back-button {
   font-size: 1.5rem;
 }
@@ -450,8 +466,22 @@ const handleSubmit = async () => {
   font-size: 1.1rem;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .fuel-record-edit-container {
+    max-width: 800px;
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .fuel-record-edit-container {
+    max-width: 900px;
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .fuel-record-edit-container {
     padding: 1rem;
   }

--- a/gasoline-record-app/src/views/FuelRecordListView.vue
+++ b/gasoline-record-app/src/views/FuelRecordListView.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="fuel-record-list-container">
     <div class="page-header">
-      <h1>給油記録</h1>
+      <div class="header-left">
+        <Button
+          icon="pi pi-home"
+          label="ホーム"
+          @click="$router.push('/')"
+          severity="secondary"
+          outlined
+        />
+        <h1>給油記録</h1>
+      </div>
       <Button
         label="新しい記録を登録"
         icon="pi pi-plus"
@@ -294,6 +303,14 @@ const handleDelete = async () => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .page-header h1 {
@@ -409,8 +426,22 @@ const handleDelete = async () => {
   font-size: 1rem;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .fuel-record-list-container {
+    max-width: 1400px;
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .fuel-record-list-container {
+    max-width: 900px;
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .fuel-record-list-container {
     padding: 1rem;
   }
@@ -418,6 +449,11 @@ const handleDelete = async () => {
   .page-header {
     flex-direction: column;
     gap: 1rem;
+    align-items: stretch;
+  }
+
+  .header-left {
+    flex-direction: column;
     align-items: stretch;
   }
 

--- a/gasoline-record-app/src/views/HomeView.vue
+++ b/gasoline-record-app/src/views/HomeView.vue
@@ -107,7 +107,7 @@ const handleLogout = async () => {
 
 .main-content {
   padding: 2rem;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -135,7 +135,6 @@ const handleLogout = async () => {
 
 .menu-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
   margin-top: 2rem;
 }
@@ -191,8 +190,34 @@ const handleLogout = async () => {
   font-weight: 600;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .menu-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .welcome-card :deep(.p-card-title) {
+    font-size: 2.5rem;
+  }
+
+  .welcome-card :deep(.p-card-content) {
+    font-size: 1.2rem;
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .menu-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .main-content {
+    max-width: 900px;
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .app-header {
     flex-direction: column;
     gap: 1rem;
@@ -200,16 +225,51 @@ const handleLogout = async () => {
   }
 
   .app-header h1 {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
+    text-align: center;
   }
 
   .user-info {
     width: 100%;
     justify-content: space-between;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .user-email {
+    font-size: 0.9rem;
   }
 
   .main-content {
     padding: 1rem;
+  }
+
+  .welcome-card :deep(.p-card-title) {
+    font-size: 1.5rem;
+  }
+
+  .welcome-card :deep(.p-card-content) {
+    font-size: 1rem;
+  }
+
+  .menu-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .menu-content {
+    padding: 1.5rem 1rem;
+  }
+
+  .menu-icon {
+    font-size: 3rem;
+  }
+
+  .menu-content h2 {
+    font-size: 1.3rem;
+  }
+
+  .menu-content p {
+    font-size: 0.95rem;
   }
 }
 </style>

--- a/gasoline-record-app/src/views/VehicleCreateView.vue
+++ b/gasoline-record-app/src/views/VehicleCreateView.vue
@@ -3,13 +3,23 @@
     <Card class="form-card">
       <template #title>
         <div class="form-header">
-          <Button
-            icon="pi pi-arrow-left"
-            @click="$router.push('/vehicles')"
-            text
-            rounded
-            class="back-button"
-          />
+          <div class="header-buttons">
+            <Button
+              icon="pi pi-home"
+              @click="$router.push('/')"
+              text
+              rounded
+              severity="secondary"
+              class="home-button"
+            />
+            <Button
+              icon="pi pi-arrow-left"
+              @click="$router.push('/vehicles')"
+              text
+              rounded
+              class="back-button"
+            />
+          </div>
           <h1>車両の登録</h1>
         </div>
       </template>
@@ -143,6 +153,12 @@ const handleSubmit = async () => {
   gap: 1rem;
 }
 
+.header-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.home-button,
 .back-button {
   font-size: 1.5rem;
 }

--- a/gasoline-record-app/src/views/VehicleEditView.vue
+++ b/gasoline-record-app/src/views/VehicleEditView.vue
@@ -8,13 +8,23 @@
     <Card v-else-if="vehicle" class="form-card">
       <template #title>
         <div class="form-header">
-          <Button
-            icon="pi pi-arrow-left"
-            @click="$router.push('/vehicles')"
-            text
-            rounded
-            class="back-button"
-          />
+          <div class="header-buttons">
+            <Button
+              icon="pi pi-home"
+              @click="$router.push('/')"
+              text
+              rounded
+              severity="secondary"
+              class="home-button"
+            />
+            <Button
+              icon="pi pi-arrow-left"
+              @click="$router.push('/vehicles')"
+              text
+              rounded
+              class="back-button"
+            />
+          </div>
           <h1>車両の編集</h1>
         </div>
       </template>
@@ -203,6 +213,12 @@ const handleSubmit = async () => {
   gap: 1rem;
 }
 
+.header-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.home-button,
 .back-button {
   font-size: 1.5rem;
 }
@@ -278,8 +294,22 @@ const handleSubmit = async () => {
   font-size: 1.1rem;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .vehicle-edit-container {
+    max-width: 800px;
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .vehicle-edit-container {
+    max-width: 900px;
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .vehicle-edit-container {
     padding: 1rem;
   }

--- a/gasoline-record-app/src/views/VehicleListView.vue
+++ b/gasoline-record-app/src/views/VehicleListView.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="vehicle-list-container">
     <div class="page-header">
-      <h1>車両管理</h1>
+      <div class="header-left">
+        <Button
+          icon="pi pi-home"
+          label="ホーム"
+          @click="$router.push('/')"
+          severity="secondary"
+          outlined
+        />
+        <h1>車両管理</h1>
+      </div>
       <Button
         label="新しい車両を登録"
         icon="pi pi-plus"
@@ -177,7 +186,7 @@ const handleDelete = async () => {
 <style scoped>
 .vehicle-list-container {
   padding: 2rem;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -186,6 +195,14 @@ const handleDelete = async () => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .page-header h1 {
@@ -293,8 +310,26 @@ const handleDelete = async () => {
   font-size: 1.1rem;
 }
 
-/* レスポンシブ対応 */
-@media (max-width: 768px) {
+/* PC画面（1200px以上） */
+@media (min-width: 1200px) {
+  .vehicle-grid {
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  }
+}
+
+/* タブレット画面（768px〜1199px） */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .vehicle-list-container {
+    max-width: 900px;
+  }
+
+  .vehicle-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* スマホ画面（768px未満） */
+@media (max-width: 767px) {
   .vehicle-list-container {
     padding: 1rem;
   }
@@ -305,6 +340,11 @@ const handleDelete = async () => {
     align-items: stretch;
   }
 
+  .header-left {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .page-header h1 {
     font-size: 1.5rem;
     text-align: center;
@@ -312,6 +352,14 @@ const handleDelete = async () => {
 
   .vehicle-grid {
     grid-template-columns: 1fr;
+  }
+
+  .card-actions {
+    flex-direction: column;
+  }
+
+  .card-actions button {
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
- 全画面にホームへ戻るボタンを追加
- レスポンシブデザインを実装（スマホ・タブレット・PC対応）
  - PC（1200px以上）: 最大幅1400px、3カラムレイアウト
  - タブレット（768px-1199px）: 最大幅900px、2カラムレイアウト
  - スマホ（768px未満）: 1カラムレイアウト、ボタン縦並び
- Supabaseセッション管理の改善
  - セッションの永続化を有効化
  - トークンの自動リフレッシュを有効化