### PR TITLE
style: ホームボタンの文字色を白に変更

### DIFF
--- a/gasoline-record-app/src/views/FuelRecordListView.vue
+++ b/gasoline-record-app/src/views/FuelRecordListView.vue
@@ -334,6 +334,21 @@ const handleDelete = async () => {
   box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
 }
 
+.header-left :deep(.p-button) {
+  background: var(--vt-c-primary);
+  border: none;
+  color: #FFFFFF;
+  border-radius: 12px;
+  padding: 0.625rem 1.25rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(91, 95, 237, 0.2);
+}
+
+.header-left :deep(.p-button:hover) {
+  background: var(--vt-c-primary-dark);
+  box-shadow: 0 4px 12px rgba(91, 95, 237, 0.3);
+}
+
 .filter-card {
   margin-bottom: 2rem;
   max-width: 600px;

--- a/gasoline-record-app/src/views/VehicleListView.vue
+++ b/gasoline-record-app/src/views/VehicleListView.vue
@@ -226,6 +226,21 @@ const handleDelete = async () => {
   box-shadow: 0 4px 12px rgba(91, 95, 237, 0.3);
 }
 
+.header-left :deep(.p-button) {
+  background: var(--vt-c-primary);
+  border: none;
+  color: #FFFFFF;
+  border-radius: 12px;
+  padding: 0.625rem 1.25rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(91, 95, 237, 0.2);
+}
+
+.header-left :deep(.p-button:hover) {
+  background: var(--vt-c-primary-dark);
+  box-shadow: 0 4px 12px rgba(91, 95, 237, 0.3);
+}
+
 .loading-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- VehicleListViewとFuelRecordListViewのホームボタンのテキストカラーを#FFFFFFに設定
- 視認性を向上させるため、プライマリーカラーの背景に白いテキストを使用