### PR TITLE
feat: ページリロード時にログイン状態を維持するように修正

### DIFF
--- a/gasoline-record-app/src/main.ts
+++ b/gasoline-record-app/src/main.ts
@@ -13,27 +13,35 @@ import App from './App.vue'
 import router from './router'
 import { useAuthStore } from './stores/auth'
 
-const app = createApp(App)
+// アプリの初期化を非同期関数で実行
+async function initializeApp() {
+  const app = createApp(App)
 
-const pinia = createPinia()
-app.use(pinia)
-app.use(router)
-app.use(PrimeVue, {
-  theme: {
-    preset: Aura,
-    options: {
-      // シニア世代向けに大きめのフォントサイズを設定
-      cssLayer: {
-        name: 'primevue',
-        order: 'tailwind-base, primevue, tailwind-utilities'
+  const pinia = createPinia()
+  app.use(pinia)
+
+  // 認証ストアを初期化してセッションを復元
+  const authStore = useAuthStore()
+  await authStore.initialize()
+
+  // 認証の初期化が完了してからルーターを設定
+  app.use(router)
+  app.use(PrimeVue, {
+    theme: {
+      preset: Aura,
+      options: {
+        // シニア世代向けに大きめのフォントサイズを設定
+        cssLayer: {
+          name: 'primevue',
+          order: 'tailwind-base, primevue, tailwind-utilities'
+        }
       }
     }
-  }
-})
-app.use(ToastService)
+  })
+  app.use(ToastService)
 
-app.mount('#app')
+  app.mount('#app')
+}
 
-// 認証ストアの初期化
-const authStore = useAuthStore()
-authStore.initialize()
+// アプリを起動
+initializeApp()

--- a/gasoline-record-app/src/router/index.ts
+++ b/gasoline-record-app/src/router/index.ts
@@ -72,6 +72,20 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore()
 
+  // 認証の初期化が完了するまで待機
+  // main.tsでawaitしているため、通常はこのケースには入らないが、
+  // より堅牢にするための追加チェック
+  if (authStore.loading) {
+    // 初期化が完了するまで待機
+    const unwatch = authStore.$subscribe(() => {
+      if (!authStore.loading) {
+        unwatch()
+        next()
+      }
+    })
+    return
+  }
+
   // 認証が必要なページ
   if (to.meta.requiresAuth) {
     if (!authStore.isAuthenticated) {


### PR DESCRIPTION
問題:
- ページをリロードするたびにログイン画面に戻ってしまう
- 認証情報はlocalStorageに保存されているが、読み込み前にルーターガードが チェックしてしまい、ログインページにリダイレクトされていた

修正内容:
1. main.ts
   - initializeApp()関数を作成し、認証の初期化を待ってからルーターを設定
   - authStore.initialize()をawaitで待機してからapp.use(router)を実行
   - これにより、localStorageからセッションを復元してからルーティングが開始される

2. router/index.ts
   - ルートガードでauthStore.loadingをチェック
   - 認証の初期化中は待機し、完了してから認証状態をチェック
   - より堅牢な実装のための追加の保護層

これにより、Supabaseの`persistSession: true`が正しく機能し、
ページリロード後もログイン状態が維持されるようになる。