### PR TITLE
fix: ダークモードを無効化して常にライトモード表示に

### DIFF
--- a/gasoline-record-app/src/assets/base.css
+++ b/gasoline-record-app/src/assets/base.css
@@ -53,7 +53,8 @@
   --section-gap: 160px;
 }
 
-@media (prefers-color-scheme: dark) {
+/* ダークモード設定を一時的に無効化 */
+/* @media (prefers-color-scheme: dark) {
   :root {
     --color-background: var(--vt-c-black);
     --color-background-soft: var(--vt-c-black-soft);
@@ -65,7 +66,7 @@
     --color-heading: var(--vt-c-white);
     --color-text: rgba(235, 235, 235, 0.64);
   }
-}
+} */
 
 *,
 *::before,


### PR DESCRIPTION
問題:
- スマホでOSのダークモード設定が有効な場合、カードや背景が黒く表示される
- PCではライトモードだが、スマホではダークモードで表示が異なる

修正内容:
- base.cssの@media (prefers-color-scheme: dark)をコメントアウト
- これによりOSの設定に関わらず、常にライトモードで表示される
- ダークモードのコードは将来の再有効化のために残している

これにより全デバイスで一貫した表示（ライトモード）になる。