### PR TITLE
fix: Vercelでのリロード時の404エラーを修正

### DIFF
--- a/gasoline-record-app/vercel.json
+++ b/gasoline-record-app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
問題:
- Vercelにデプロイした際、パス付きのURL（例: /login）でリロードすると404エラーが発生
- SPAではクライアントサイドルーティングを使用しているが、サーバー側に 実際のファイルが存在しないため、リロード時にサーバーが404を返していた

修正内容:
- プロジェクトルートとアプリディレクトリの両方にvercel.jsonを追加
- rewrites設定ですべてのリクエストを/index.htmlにリダイレクト
- これにより、どのパスでアクセスしてもindex.htmlが返され、 Vue Routerがクライアントサイドで正しいルートを処理できるようになる

Vercelの設定:
- Root Directoryが未設定の場合: プロジェクトルートのvercel.jsonが使用される
- Root Directoryが「gasoline-record-app」の場合: アプリ内のvercel.jsonが使用される
- どちらの設定でも正しく動作するように両方に配置