### PR TITLE
fix: PrimeVueのダークモード自動検出を無効化

### DIFF
--- a/gasoline-record-app/src/main.ts
+++ b/gasoline-record-app/src/main.ts
@@ -30,6 +30,9 @@ async function initializeApp() {
     theme: {
       preset: Aura,
       options: {
+        // PrimeVueのダークモード自動検出を無効化（常にライトモード表示）
+        // OSのprefers-color-schemeに関わらず、ライトモードのみを使用する
+        darkModeSelector: false,
         // シニア世代向けに大きめのフォントサイズを設定
         cssLayer: {
           name: 'primevue',


### PR DESCRIPTION
問題:
- base.cssのダークモード設定をコメントアウトしても、スマホでカードの背景が黒いまま
- PrimeVue Auraテーマがデフォルトでprefers-color-schemeを検出し、 OSのダークモード設定に応じて自動的にダークモードを適用していた
- Cardなどのコンポーネントの背景色はPrimeVue自体のテーマシステムで管理されている

修正内容:
- main.tsのPrimeVue設定にdarkModeSelector: falseを追加
- これによりPrimeVueのダークモード自動検出が無効化される
- OSの設定に関わらず、常にライトモードで表示されるようになる

参考:
- https://primevue.org/theming/styled/
- https://github.com/primefaces/primevue/issues/6102