### PR TITLE
fix: 車両更新時のリアクティビティ問題を修正

### DIFF
--- a/gasoline-record-app/src/stores/vehicle.ts
+++ b/gasoline-record-app/src/stores/vehicle.ts
@@ -102,9 +102,10 @@ export const useVehicleStore = defineStore('vehicle', () => {
       }
 
       // ローカルの配列を更新
+      // Vue のリアクティビティを確実にトリガーするため、splice() を使用
       const index = vehicles.value.findIndex((v) => v.id === id)
       if (index !== -1 && data) {
-        vehicles.value[index] = data
+        vehicles.value.splice(index, 1, data)
       }
 
       return data


### PR DESCRIPTION
問題:
- 車両情報を更新しても、一覧画面で更新が反映されない
- vehicle.tsのupdateVehicle()で配列の要素を直接置き換えていた （vehicles.value[index] = data）
- Vueのリアクティビティシステムが配列の直接置換を検出できない場合がある

修正内容:
- vehicles.value[index] = data を vehicles.value.splice(index, 1, data) に変更
- splice()メソッドを使用することで、Vueが確実に配列の変更を検出できる
- これにより、車両情報の更新が即座にUIに反映されるようになる

補足:
- fuelRecord.tsは配列全体を新しく作り直しているため問題なし
- 一覧画面ではonMountedでfetchしているが、ストアの更新が 正しく反映されないと、編集画面での即座の更新も機能しない