### PR TITLE
fix: 給油記録の日付が一日前になる問題を修正

### DIFF
--- a/gasoline-record-app/src/views/FuelRecordCreateView.vue
+++ b/gasoline-record-app/src/views/FuelRecordCreateView.vue
@@ -255,7 +255,12 @@ const handleSubmit = async () => {
   }
 
   try {
-    const dateString = currentDate.toISOString().split('T')[0] as string
+    // ローカルタイムゾーンでYYYY-MM-DD形式の文字列を作成
+    // toISOString()はUTCに変換されるため、タイムゾーンによって日付がずれる問題を回避
+    const year = currentDate.getFullYear()
+    const month = String(currentDate.getMonth() + 1).padStart(2, '0')
+    const day = String(currentDate.getDate()).padStart(2, '0')
+    const dateString = `${year}-${month}-${day}`
 
     await fuelRecordStore.createRecord(
       currentVehicleId,

--- a/gasoline-record-app/src/views/FuelRecordEditView.vue
+++ b/gasoline-record-app/src/views/FuelRecordEditView.vue
@@ -299,7 +299,12 @@ const handleSubmit = async () => {
   }
 
   try {
-    const dateString = currentDate.toISOString().split('T')[0] as string
+    // ローカルタイムゾーンでYYYY-MM-DD形式の文字列を作成
+    // toISOString()はUTCに変換されるため、タイムゾーンによって日付がずれる問題を回避
+    const year = currentDate.getFullYear()
+    const month = String(currentDate.getMonth() + 1).padStart(2, '0')
+    const day = String(currentDate.getDate()).padStart(2, '0')
+    const dateString = `${year}-${month}-${day}`
 
     await fuelRecordStore.updateRecord(
       recordId.value,


### PR DESCRIPTION
問題:
- 給油記録の編集画面や登録画面で日付を選択すると、一日前の日付が登録される
- 例: 2024年1月15日を選択 → 2024年1月14日が登録される

原因:
- toISOString()はUTC（協定世界時）で日付を返す
- 日本時間（JST, UTC+9）で2024年1月15日 00:00:00を選択した場合、 UTCでは2024年1月14日 15:00:00になる
- toISOString()は "2024-01-14T15:00:00.000Z" を返し、 split('T')[0]で取得すると "2024-01-14" になってしまう

修正内容:
- toISOString()を使わず、ローカルタイムゾーンで日付文字列を作成
- getFullYear(), getMonth(), getDate()を使用してYYYY-MM-DD形式の文字列を生成
- これにより、ユーザーが選択した日付がそのまま登録されるようになる

修正ファイル:
- FuelRecordEditView.vue (編集画面)
- FuelRecordCreateView.vue (登録画面)